### PR TITLE
FIX: Show usercard when tapping avatar

### DIFF
--- a/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
@@ -3,7 +3,7 @@
   {{~#if showMobileAvatar}}
   <div class='pull-left'>
     {{!-- updated to show OP avatar --}}
-    <a href="{{topic.firstPostUrl}}">{{avatar topic.creator imageSize="large"}}</a>
+    <a href="{{topic.firstPostUrl}}"  data-user-card="{{topic.creator.username}}">{{avatar topic.creator imageSize="large"}}</a>
   </div>
   <div class='right'>
     {{else}}


### PR DESCRIPTION
Currently the avatar brings you to their profile, this allows the usercard to appear instead. 