### PR TITLE
Update topic-list-item.hbr to keep in sync with the core

### DIFF
--- a/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
@@ -1,8 +1,14 @@
 <td class="topic-list-data">
   {{~raw-plugin-outlet name="topic-list-before-columns"}}
   <div class='pull-left topic-list-avatar'>
-    {{!-- updated to show OP avatar --}}
-    <a href="{{topic.firstPostUrl}}"  data-user-card="{{topic.creator.username}}">{{avatar topic.creator imageSize="large"}}</a>
+    {{#if bulkSelectEnabled}}
+      <label for="bulk-select-{{topic.id}}">
+        <input type="checkbox" class="bulk-select" id="bulk-select-{{topic.id}}">
+      </label>
+    {{else}}
+      {{!-- updated to show OP avatar --}}
+      <a href="{{topic.firstPostUrl}}"  data-user-card="{{topic.creator.username}}">{{avatar topic.creator imageSize="large"}}</a>
+    {{/if}}
   </div>
   <div class='right topic-list-content'>
     {{!--


### PR DESCRIPTION
This theme component is outdated and doesn’t contain the following code, which prevents bulk-select functionality for admins on mobile.

https://github.com/Lhcfl/discourse-mobile-op-avatar-component/blob/894d6ed94b929c66eca58a4ab004ca5eb9b33515/javascripts/discourse/templates/mobile/list/topic-list-item.hbr#L4-L7

This PR fixed this problem.